### PR TITLE
Fix for selects not working in IE8

### DIFF
--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -1,6 +1,6 @@
 uis.directive('uiSelectChoices',
-  ['uiSelectConfig', 'uisRepeatParser', 'uiSelectMinErr', '$compile',
-  function(uiSelectConfig, RepeatParser, uiSelectMinErr, $compile) {
+  ['uiSelectConfig', 'uisRepeatParser', 'uiSelectMinErr', '$compile', '$window',
+  function(uiSelectConfig, RepeatParser, uiSelectMinErr, $compile, $window) {
 
   return {
     restrict: 'EA',
@@ -40,7 +40,7 @@ uis.directive('uiSelectChoices',
 
         choices.attr('ng-repeat', RepeatParser.getNgRepeatExpression($select.parserResult.itemName, '$select.items', $select.parserResult.trackByExp, groupByExp))
             .attr('ng-if', '$select.open'); //Prevent unnecessary watches when dropdown is closed
-        if (document.addEventListener) {  //crude way to exclude IE8, specifically, which also cannot capture events
+        if ($window.document.addEventListener) {  //crude way to exclude IE8, specifically, which also cannot capture events
           choices.attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
               .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
         }
@@ -48,7 +48,7 @@ uis.directive('uiSelectChoices',
         var rowsInner = element.querySelectorAll('.ui-select-choices-row-inner');
         if (rowsInner.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row-inner but got '{0}'.", rowsInner.length);
         rowsInner.attr('uis-transclude-append', ''); //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
-        if (!document.addEventListener) {  //crude way to target IE8, specifically, which also cannot capture events - so event bindings must be here
+        if (!$window.document.addEventListener) {  //crude way to target IE8, specifically, which also cannot capture events - so event bindings must be here
           rowsInner.attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
               .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
         }

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -39,14 +39,14 @@ uis.directive('uiSelectChoices',
         }
 
         choices.attr('ng-repeat', RepeatParser.getNgRepeatExpression($select.parserResult.itemName, '$select.items', $select.parserResult.trackByExp, groupByExp))
-            .attr('ng-if', '$select.open') //Prevent unnecessary watches when dropdown is closed
-            .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
-            .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
+            .attr('ng-if', '$select.open'); //Prevent unnecessary watches when dropdown is closed
 
         var rowsInner = element.querySelectorAll('.ui-select-choices-row-inner');
         if (rowsInner.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row-inner but got '{0}'.", rowsInner.length);
-        rowsInner.attr('uis-transclude-append', ''); //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
-
+        rowsInner.attr('uis-transclude-append', '') //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
+          .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
+          .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
+          
         $compile(element, transcludeFn)(scope); //Passing current transcludeFn to be able to append elements correctly from uisTranscludeAppend
 
         scope.$watch('$select.search', function(newValue) {

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -39,14 +39,14 @@ uis.directive('uiSelectChoices',
         }
 
         choices.attr('ng-repeat', RepeatParser.getNgRepeatExpression($select.parserResult.itemName, '$select.items', $select.parserResult.trackByExp, groupByExp))
-            .attr('ng-if', '$select.open') //Prevent unnecessary watches when dropdown is closed
-            .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')');
+            .attr('ng-if', '$select.open'); //Prevent unnecessary watches when dropdown is closed
 
         var rowsInner = element.querySelectorAll('.ui-select-choices-row-inner');
         if (rowsInner.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row-inner but got '{0}'.", rowsInner.length);
         rowsInner.attr('uis-transclude-append', '') //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
+          .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
           .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
-
+          
         $compile(element, transcludeFn)(scope); //Passing current transcludeFn to be able to append elements correctly from uisTranscludeAppend
 
         scope.$watch('$select.search', function(newValue) {

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -40,7 +40,7 @@ uis.directive('uiSelectChoices',
 
         choices.attr('ng-repeat', RepeatParser.getNgRepeatExpression($select.parserResult.itemName, '$select.items', $select.parserResult.trackByExp, groupByExp))
             .attr('ng-if', '$select.open'); //Prevent unnecessary watches when dropdown is closed
-        if (typeof window.document.addEventListener !== 'undefined') {  //crude way to exclude IE8, specifically, which also cannot capture events
+        if (document.addEventListener) {  //crude way to exclude IE8, specifically, which also cannot capture events
           choices.attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
               .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
         }
@@ -48,7 +48,7 @@ uis.directive('uiSelectChoices',
         var rowsInner = element.querySelectorAll('.ui-select-choices-row-inner');
         if (rowsInner.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row-inner but got '{0}'.", rowsInner.length);
         rowsInner.attr('uis-transclude-append', ''); //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
-        if (typeof window.document.addEventListener === 'undefined') {  //crude way to target IE8, specifically, which also cannot capture events - so event bindings must be here
+        if (!document.addEventListener) {  //crude way to target IE8, specifically, which also cannot capture events - so event bindings must be here
           rowsInner.attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
               .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
         }

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -39,14 +39,14 @@ uis.directive('uiSelectChoices',
         }
 
         choices.attr('ng-repeat', RepeatParser.getNgRepeatExpression($select.parserResult.itemName, '$select.items', $select.parserResult.trackByExp, groupByExp))
-            .attr('ng-if', '$select.open'); //Prevent unnecessary watches when dropdown is closed
+            .attr('ng-if', '$select.open') //Prevent unnecessary watches when dropdown is closed
+            .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
+            .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
 
         var rowsInner = element.querySelectorAll('.ui-select-choices-row-inner');
         if (rowsInner.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row-inner but got '{0}'.", rowsInner.length);
-        rowsInner.attr('uis-transclude-append', '') //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
-          .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
-          .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
-          
+        rowsInner.attr('uis-transclude-append', ''); //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
+
         $compile(element, transcludeFn)(scope); //Passing current transcludeFn to be able to append elements correctly from uisTranscludeAppend
 
         scope.$watch('$select.search', function(newValue) {

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -39,13 +39,19 @@ uis.directive('uiSelectChoices',
         }
 
         choices.attr('ng-repeat', RepeatParser.getNgRepeatExpression($select.parserResult.itemName, '$select.items', $select.parserResult.trackByExp, groupByExp))
-            .attr('ng-if', '$select.open') //Prevent unnecessary watches when dropdown is closed
-            .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
-            .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
+            .attr('ng-if', '$select.open'); //Prevent unnecessary watches when dropdown is closed
+        if (typeof window.document.addEventListener !== 'undefined') {  //crude way to exclude IE8, specifically, which also cannot capture events
+          choices.attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
+              .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
+        }
 
         var rowsInner = element.querySelectorAll('.ui-select-choices-row-inner');
         if (rowsInner.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row-inner but got '{0}'.", rowsInner.length);
         rowsInner.attr('uis-transclude-append', ''); //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
+        if (typeof window.document.addEventListener === 'undefined') {  //crude way to target IE8, specifically, which also cannot capture events - so event bindings must be here
+          rowsInner.attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
+              .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
+        }
 
         $compile(element, transcludeFn)(scope); //Passing current transcludeFn to be able to append elements correctly from uisTranscludeAppend
 

--- a/src/uiSelectChoicesDirective.js
+++ b/src/uiSelectChoicesDirective.js
@@ -39,14 +39,14 @@ uis.directive('uiSelectChoices',
         }
 
         choices.attr('ng-repeat', RepeatParser.getNgRepeatExpression($select.parserResult.itemName, '$select.items', $select.parserResult.trackByExp, groupByExp))
-            .attr('ng-if', '$select.open'); //Prevent unnecessary watches when dropdown is closed
+            .attr('ng-if', '$select.open') //Prevent unnecessary watches when dropdown is closed
+            .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')');
 
         var rowsInner = element.querySelectorAll('.ui-select-choices-row-inner');
         if (rowsInner.length !== 1) throw uiSelectMinErr('rows', "Expected 1 .ui-select-choices-row-inner but got '{0}'.", rowsInner.length);
         rowsInner.attr('uis-transclude-append', '') //Adding uisTranscludeAppend directive to row element after choices element has ngRepeat
-          .attr('ng-mouseenter', '$select.setActiveItem('+$select.parserResult.itemName +')')
           .attr('ng-click', '$select.select(' + $select.parserResult.itemName + ',false,$event)');
-          
+
         $compile(element, transcludeFn)(scope); //Passing current transcludeFn to be able to append elements correctly from uisTranscludeAppend
 
         scope.$watch('$select.search', function(newValue) {


### PR DESCRIPTION
https://github.com/angular-ui/ui-select/issues/158, based on an observed (but maybe not well understood) code change by @careywalker. Basically, just move the ng-click/ng-mouseenter bindings from the LI (choices-row) to the contained DIV (choices-row-inner). So far, I haven't seen an affect on behavior in any browser, but this is with light manual testing.

All automated tests pass with these changes in place:

> gulp test
> [15:05:36] Using gulpfile C:\web\sites\ui-select\gulpfile.js
> [15:05:36] Starting 'clean'...
> [15:05:36] Finished 'clean' after 14 ms
> [15:05:36] Starting 'scripts'...
> [15:05:36] Starting 'styles'...
> [15:05:36] Finished 'styles' after 61 ms
> [15:05:37] Finished 'scripts' after 1.01 s
> [15:05:37] Starting 'build'...
> [15:05:37] Finished 'build' after 14 μs
> [15:05:37] Starting 'karma'...
> [15:05:38] Finished 'karma' after 880 ms
> [15:05:38] Starting 'test'...
> [15:05:38] Finished 'test' after 5.63 μs
> INFO [karma]: Karma v0.12.31 server started at http://localhost:9876/
> INFO [launcher]: Starting browser Chrome
> INFO [Chrome 41.0.2272 (Windows 7)]: Connected on socket gaw3nxxZW2Omee4BBX-X with id 17666700
> Chrome 41.0.2272 (Windows 7): Executed 110 of 110 SUCCESS (2.483 secs / 2.465 secs)
